### PR TITLE
Refactor

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/client/controller/RiotClientController.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/controller/RiotClientController.java
@@ -1,6 +1,6 @@
 package com.summoner.lolhaeduo.client.controller;
 
-import com.summoner.lolhaeduo.domain.gamedata.scheduler.DataDragonScheduler;
+import com.summoner.lolhaeduo.infrastructure.scheduler.DataDragonScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -13,6 +13,7 @@ import com.summoner.lolhaeduo.domain.account.repository.AccountRepository;
 import com.summoner.lolhaeduo.domain.account.repository.dataStorage.FlexRankDataRepository;
 import com.summoner.lolhaeduo.domain.account.repository.dataStorage.QuickGameDataRepository;
 import com.summoner.lolhaeduo.domain.account.repository.dataStorage.SoloRankDataRepository;
+import com.summoner.lolhaeduo.domain.account.service.riot.RiotGameDataService;
 import com.summoner.lolhaeduo.domain.duo.entity.Kda;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
@@ -6,6 +6,7 @@ import com.summoner.lolhaeduo.domain.account.dto.LinkAccountResponse;
 import com.summoner.lolhaeduo.domain.account.entity.Account;
 import com.summoner.lolhaeduo.domain.account.entity.AccountDetail;
 import com.summoner.lolhaeduo.domain.account.repository.AccountRepository;
+import com.summoner.lolhaeduo.domain.account.service.riot.RiotGameDataService;
 import com.summoner.lolhaeduo.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/riot/RiotGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/riot/RiotGameDataService.java
@@ -1,4 +1,4 @@
-package com.summoner.lolhaeduo.domain.account.service;
+package com.summoner.lolhaeduo.domain.account.service.riot;
 
 import com.summoner.lolhaeduo.client.dto.api.LeagueEntryResponse;
 import com.summoner.lolhaeduo.client.dto.api.PuuidResponse;

--- a/src/main/java/com/summoner/lolhaeduo/infrastructure/scheduler/AccountGameDataScheduler.java
+++ b/src/main/java/com/summoner/lolhaeduo/infrastructure/scheduler/AccountGameDataScheduler.java
@@ -1,4 +1,4 @@
-package com.summoner.lolhaeduo.domain.account.scheduler;
+package com.summoner.lolhaeduo.infrastructure.scheduler;
 
 import com.summoner.lolhaeduo.domain.account.entity.Account;
 import com.summoner.lolhaeduo.domain.account.repository.AccountRepository;

--- a/src/main/java/com/summoner/lolhaeduo/infrastructure/scheduler/DataDragonScheduler.java
+++ b/src/main/java/com/summoner/lolhaeduo/infrastructure/scheduler/DataDragonScheduler.java
@@ -1,4 +1,4 @@
-package com.summoner.lolhaeduo.domain.gamedata.scheduler;
+package com.summoner.lolhaeduo.infrastructure.scheduler;
 
 import com.summoner.lolhaeduo.domain.gamedata.entity.Champion;
 import com.summoner.lolhaeduo.domain.gamedata.entity.ProfileIcon;


### PR DESCRIPTION
## 1. 스케줄러를 Infrastructure 계층으로 이동
> Clean Architecture 의존성 방향 원칙에 따라 분산된 스케줄러를 Infrastructure 계층으로 통합 이동

**[AS-IS]**
- 도메인별로 분산된 스케줄링 관심사
- Clean Architecture 의존성 방향 원칙 위반
- 스케줄링 설정 관리의 비일관성

**[TO-BE]**
- Infrastructure → Domain 올바른 의존성 방향
- 모든 스케줄링 작업을 한 곳에서 중앙 관리
- 도메인 순수성 보장


### 🪄 개선 효과
1. **Clean Architecture 준수**: 외부 관심사(스케줄링)를 Infrastructure 계층에 배치
2. **관심사 분리**: 도메인 로직과 스케줄링 로직 명확한 구분
3. **중앙 집중화**: 스케줄링 설정 및 관리의 일관성 확보
4. **의존성 정리**: 계층 간 올바른 관계 구축

<br>

## 2. RiotGameDataService 패키지 분리
> 복잡한 외부 API 연동 서비스와 순수 도메인 서비스의 명확한 책임 분리


### 🎯 설계 원칙 적용
1. **단일 책임 원칙**: 순수 도메인 로직 vs 외부 API 연동 로직 분리
2. **복잡성 격리**: 외부 의존성을 별도 패키지에서 관리
3. **확장성 확보**: `service/riot/`, `service/steam/` 등 확장 가능한 구조


### 🪄 개선 효과
1. **가독성 향상**: 패키지 구조로 역할 파악 가능
2. **유지 보수성**: 외부 API 변경 사항의 영향 범위 최소화
3. **테스트 용이성**: 복잡한 외부 의존성 격리로 Mock 처리 단순화
4. **확장성**: 향후 다른 게임 플랫폼 API 추가 시 일관된 패턴 적용